### PR TITLE
Fix typos

### DIFF
--- a/bruces/_catalog.py
+++ b/bruces/_catalog.py
@@ -193,13 +193,13 @@ class Catalog:
         w : scalar, optional, default 1.0
             Only if ``algorithm = "nearest-neighbor"``. Magnitude weighting factor (usually b-value).
         use_depth : bool, optional, default False
-            Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"`. If `True`, consider depth in interevent distance calculation.
+            Only if ``algorithm = "nearest-neighbor"``. If `True`, consider depth in interevent distance calculation.
         eta_0 : scalar or None, optional, default None
-            Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"`. Initial cutoff threshold. If `None`, invoke :meth:`bruces.Catalog.fit_cutoff_threshold`.
+            Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"``. Initial cutoff threshold. If `None`, invoke :meth:`bruces.Catalog.fit_cutoff_threshold`.
         alpha_0 : scalar, optional, default 1.5
-            Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"`. Cluster threshold.
+            Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"``. Cluster threshold.
         M : int, optional, default 16
-            Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"`. Number of reshufflings.
+            Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"``. Number of reshufflings.
         seed : int or None, optional, default None
             Only if ``algorithm = "nearest-neighbor"``. Seed for random number generator.
         rfact : int, optional, default 10

--- a/bruces/decluster/_helpers.py
+++ b/bruces/decluster/_helpers.py
@@ -49,13 +49,13 @@ def decluster(catalog, algorithm="nearest-neighbor", return_indices=False, **kwa
     w : scalar, optional, default 1.0
         Only if ``algorithm = "nearest-neighbor"``. Magnitude weighting factor (usually b-value).
     use_depth : bool, optional, default False
-        Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"`. If `True`, consider depth in interevent distance calculation.
+        Only if ``algorithm = "nearest-neighbor"``. If `True`, consider depth in interevent distance calculation.
     eta_0 : scalar or None, optional, default None
-        Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"`. Initial cutoff threshold. If `None`, invoke :meth:`bruces.Catalog.fit_cutoff_threshold`.
+        Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"``. Initial cutoff threshold. If `None`, invoke :meth:`bruces.Catalog.fit_cutoff_threshold`.
     alpha_0 : scalar, optional, default 1.5
-        Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"`. Cluster threshold.
+        Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"``. Cluster threshold.
     M : int, optional, default 16
-        Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"`. Number of reshufflings.
+        Only if ``algorithm = "nearest-neighbor"`` and ``method = "thinning"``. Number of reshufflings.
     seed : int or None, optional, default None
         Only if ``algorithm = "nearest-neighbor"``. Seed for random number generator.
     rfact : int, optional, default 10

--- a/bruces/decluster/nearest_neighbor/_nearest_neighbor.py
+++ b/bruces/decluster/nearest_neighbor/_nearest_neighbor.py
@@ -42,11 +42,11 @@ def decluster(
     use_depth : bool, optional, default False
         If `True`, consider depth in interevent distance calculation.
     eta_0 : scalar or None, optional, default None
-        Only if ``method = "thinning"`. Initial cutoff threshold. If `None`, invoke :meth:`bruces.Catalog.fit_cutoff_threshold`.
+        Only if ``method = "thinning"``. Initial cutoff threshold. If `None`, invoke :meth:`bruces.Catalog.fit_cutoff_threshold`.
     alpha_0 : scalar, optional, default 1.5
-        Only if ``method = "thinning"`. Cluster threshold.
+        Only if ``method = "thinning"``. Cluster threshold.
     M : int, optional, default 16
-        Only if ``method = "thinning"`. Number of reshufflings.
+        Only if ``method = "thinning"``. Number of reshufflings.
     seed : int or None, optional, default None
         Seed for random number generator.
 


### PR DESCRIPTION
- Fixed: typos in docstrings

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
